### PR TITLE
Define \citealp as alias for \cite in cite-package setup

### DIFF
--- a/tex/lib/dependencies.tex
+++ b/tex/lib/dependencies.tex
@@ -199,3 +199,4 @@
 
 \let\citep\cite
 \let\citet\cite
+\let\citealp\cite


### PR DESCRIPTION
The methods.tex file uses \citealp{Lenski2003Evolutionary} (introduced in PR #100) but the project uses the cite package rather than natbib, so \citealp was undefined and caused the LaTeX build to fail with "Undefined control sequence." Match the existing \citep / \citet pattern.

https://claude.ai/code/session_01MCee22Mf7HARtuyFZyV8Bh