### PR TITLE
Fix typos and improve clarity in manuscript text (#13)

### DIFF
--- a/tex/text/body/conclusion.tex
+++ b/tex/text/body/conclusion.tex
@@ -1,7 +1,7 @@
 \section{Conclusion} \label{sec:conclusion}
 
 How information is represented within genomes and the evolutionary processes through which it accumulates is a fundamental pillar of biological science \citep{adami2024evolution}.
-Among other topics, important questions remain about the evolutionary role in structuring and extending genetic information.
+Among other topics, important questions remain about the evolutionary role of gene duplication in structuring and extending genetic information.
 One challenge to developing a rigorous and detailed understanding of gene duplications is the difficulty of realizing biological experiments to explore a counterfactual case absent gene duplication.
 By leveraging an \textit{in silico} study system that may be arbitrarily manipulated and exactly observed, our experimental approach seeks to deepen and systematize our understanding of the evolutionary consequences of gene duplications.
 

--- a/tex/text/body/introduction.tex
+++ b/tex/text/body/introduction.tex
@@ -41,7 +41,7 @@ Causality appears direct, as coding sites for these complex traits trace back to
 Thus, we also confirm that gene duplication can facilitate otherwise unlikely innovation in adaptation-driven scenarios \citep{ohno1970evolution}.
 
 Figure \ref{fig:slip_mut_variants} details our experimental design.
-Digital organisms were well-mixed, with population carrying capacity of $3{\small,}600$.
+Digital organisms were well mixed, with population carrying capacity of $3{\small,}600$.
 To supply adaptive potential, rewards were provided for each of Lenski \textit{et al.}'s collection of nine phenotypic traits (different logical transforms on binary inputs) \citep{Lenski2003Evolutionary}.
 Under this scheme, organisms producing correct output received a metabolic boost to their genetic operations.
 Formally, complexity of each task can be described as a minimum quantity of necessary NAND operations \citep{Lenski2003Evolutionary}.
@@ -60,7 +60,7 @@ Under baseline conditions, these slip mutations allow arbitrary segments of prog
 %Due to their inherent co-occurrence, it is not obvious how to disentangle these aspects of gene duplication in field or laboratory studies.
 As overviewed in Figure \ref{fig:slip_mut_variants}, we also tested a series of partial analogs for gene duplication, designed to tease apart causality in greater detail.
 Experiments began with 100-site genomes.
-To control for the effects of genome length, we also included trials with longer $1{\small,}000$-site genomes, just below the maximum $1{\small,}016$-site genome size observed along extant lineages under slip duplication and near the upper extreme of 870-site genome length fixed (Figure \ref{fig:num-coding-sites:vestigial}, Supplementary Figure \ref{fig:ablation-site-counts}).
+To control for the effects of genome length, we also included trials with longer $1{\small,}000$-site genomes, just below the maximum $1{\small,}016$-site genome size observed along extant lineages under slip duplication and near the upper extreme of fixed genome length, at 870 sites (Figure \ref{fig:num-coding-sites:vestigial}, Supplementary Figure \ref{fig:ablation-site-counts}).
 
 % \subsection{Major Results}
 

--- a/tex/text/body/methods.tex
+++ b/tex/text/body/methods.tex
@@ -10,7 +10,7 @@ Experiments reported here extend an earlier conference publication \citep{laleji
 
 Populations were well mixed and configured to the Avida default size of 3,600 organisms across all trials.
 We configured available metabolic resources consisting of tasks NOT, NAND, OR-NOT, AND, OR, AND-NOT, NOR, XOR, and EQUALS.
-(This task set comprises all unique 1 and 2-input boolean logic functions.)
+(This task set comprises all unique 1- and 2-input boolean logic functions.)
 Identical reward was provided for performing each task and kept consistent throughout trials.
 Rewards accrued independently for each task, allowing fitness benefits to be compounded by performing multiple tasks.
 In some analyses, we report a count of adaptive phenotypic traits, ranging from a minimum of 0 (\textit{i.e.,} the organism performs no tasks and receives no reward) to a maximum of 9 (\textit{i.e.,} the organism performs all 9 available tasks and receives the maximum reward).
@@ -76,7 +76,7 @@ First-phase data was used for analyses comparing evolved adaptive phenotypic tra
 For second-phase experiments, we included an additional \textbf{long-genome baseline treatment} to directly test the adaptive role of large genome size associated with slip-duplicators.
 Genomes in this treatment operated identically to those in the baseline treatment above, except that they were initialized with a 1,000-site ancestor.
 The 1,000-site length was chosen to approximate the upper bound of genome sizes observed in first-phase slip-duplication treatment experiments.
-Second-phase data was used for analyses of task gain by complexity class (Figure \ref{fig:adaptive-evolution-rate}), analyses of coding site count trajectories (Figure \ref{fig:num-coding-sites}), potentiation analyses (Figures \cref{fig:potentiation,fig:potentiation-supp}) and analyses of slip-duplication outcome distributions (Figure \ref{fig:nulldist}).
+Second-phase data was used for analyses of task gain by complexity class (Figure \ref{fig:adaptive-evolution-rate}), analyses of coding site count trajectories (Figure \ref{fig:num-coding-sites}), potentiation analyses (\Cref{fig:potentiation,fig:potentiation-supp}), and analyses of slip-duplication outcome distributions (Figure \ref{fig:nulldist}).
 Adaptation outcomes shown in Figure \ref{fig:results_panels} were also derived from second-phase experiments.
 
 For experiments incorporating the long-genome baseline control, timecourses of adaptive evolution were compared in terms of generations, rather than in terms of updates (simulation timesteps).

--- a/tex/text/body/results-and-discussion.tex
+++ b/tex/text/body/results-and-discussion.tex
@@ -5,7 +5,7 @@
 \input{fig/results_panels_new.tex}
 
 In a first set of experiments, we investigated whether gene duplication can promote \textit{de novo} evolution of adaptive phenotypic traits.
-In evolutionary trials, \textit{slip-duplicate} replicates allowing duplications did evolve more adaptive traits than under baseline conditions (median 7 vs. 9 traits; two-tailed Mann-Whitney U test, $W = 562.5$, Bonferroni-adjusted $p << 0.0001$; Figure \ref{fig:results_panels:slip_duplication}).
+In evolutionary trials, \textit{slip-duplicate} replicates allowing duplications did evolve more adaptive traits than under baseline conditions (median 9 vs. 7 traits; two-tailed Mann-Whitney U test, $W = 562.5$, Bonferroni-adjusted $p << 0.0001$; Figure \ref{fig:results_panels:slip_duplication}).
 In many cases, gene duplication drove substantial genome expansion --- inflations up to 10-fold in size, mean 546 sites (Figure \ref{fig:num-coding-sites:total}).
 To test whether genome size alone could account for gene duplication's adaptive benefit, we performed additional experiments incorporating a ``long-genome'' control treatment with 1,000-site genomes.
 
@@ -104,12 +104,12 @@ One possible confounding factor in coding site analysis is mutational sensitivit
 These sites are critical to viability, with lethal outcomes when knocked out.
 We found that these critical sites were indeed less likely to be involved in duplication and also less likely to be involved in coding for \textit{de novo} traits.
 % Hence, a spurious correlation could be introduced.
-However, after excluding fitness-critical sites from analysis, we still found generally similar potentiation signatures from duplication (Supplemental Figure \ref{fig:potentiation-supp}).
+However, after excluding fitness-critical sites from analysis, we still found generally similar potentiation signatures from duplication (Supplementary Figure \ref{fig:potentiation-supp}).
 
 In addition to potentiating effects, gene duplications are also hypothesized to facilitate adaptation through direct effects --- for example, by altering gene product dosage \citep{kondrashov2012gene}.
 % https://github.com/chaynes2019/AvidaGeneDupe/blob/61ea29d989ebc8ad83dcfee94f3fa556b81e3f78/binder/gain-mechanism.ipynb
 Indeed, we observed such direct effects in our system: a substantial fraction of novel gain-of-function steps on lineages coincided with duplications --- 41 of 174, or 23.6\%.
-However, in cases where duplication produced immediate gain-of-function, we still found evidence that sites coding for a new trait were more likely than chance to have been involved in earlier duplications (Supplemental Figure \ref{fig:potentiation-supp}).
+However, in cases where duplication produced immediate gain-of-function, we still found evidence that sites coding for a new trait were more likely than chance to have been involved in earlier duplications (Supplementary Figure \ref{fig:potentiation-supp}).
 % @AML, moved the line below to the discussion
 % Thus, the adaptive characteristics of slip duplication observed in our system seem likely to result from a combination of potentiation and direct facilitation.
 
@@ -206,10 +206,10 @@ Lastly, echoing how gene duplication especially benefited complex adaptation, li
 
 \subsection{Gene duplications accumulate vestigial coding material}
 
-Consistent with other findings that duplication-associated redundancy can boost robustness \citep{Lynch2000}, gene duplications tended to immediately reduce single points of failure detectable in knockouts (Supplemental Figure \ref{fig:nulldist}).
+Consistent with other findings that duplication-associated redundancy can boost robustness \citep{Lynch2000}, gene duplications tended to immediately reduce single points of failure detectable in knockouts (Supplementary Figure \ref{fig:nulldist}).
 Over time, however, gene duplication actually led to more mutationally-sensitive coding sites --- similar in quantity to the long-genome control.
 One possible explanation is that, despite duplications boosting redundancy in the short term, long-term balance between drift and mutational load drives convergence towards similar mutational sensitivity for large genomes.
 
 Notably, gene duplication diverges from control treatments in greatly increasing net supply of vestigial coding sites no longer constrained by selection (Figure \ref{fig:num-coding-sites}).
-Thus, we observe gene duplication to reshape genome architecture by expanding size, but to also produce an outsize pool of defunct coding content --- ripe to be co-opted.
+Thus, we observe gene duplication to reshape genome architecture by expanding size, but to also produce an outsized pool of defunct coding content --- ripe to be co-opted.
 Here, as throughout this study, site-by-site genome histories and robust experimental controls highlight an apparent evolutionary role of genetic information carried within duplications.


### PR DESCRIPTION
* Fix proofreading typos and inconsistencies in manuscript

- abstract: rewrite "duplications grew genome size... larger than" to compare like with like
- introduction: clarify "near the upper extreme of fixed genome length, at 870 sites"
- introduction: drop hyphen in predicate "well mixed" to match methods.tex (PLOS/AMA style)
- methods: fix suspended hyphen "1- and 2-input"
- methods: drop redundant literal "Figures" before \cref; add Oxford comma
- results: fix swapped numbers ("median 9 vs. 7 traits")
- results: "multiple comparison" -> "multiple comparisons"
- results: remove redundant "On the other hand, however,"
- results: standardize on "Supplementary Figure" (PLOS style)
- results: "outsize pool" -> "outsized pool"
- conclusion: add missing subject "evolutionary role of gene duplication"

* Revert abstract.tex line 10 per review feedback

* Use \Cref (capitalized) for figure cross-reference

* Revert results-and-discussion.tex line 36 per review feedback

* Revert results-and-discussion.tex line 173 per review feedback

---------